### PR TITLE
Creating a single RequestData for many imp, changed fixture

### DIFF
--- a/adapters/telaria/telaria.go
+++ b/adapters/telaria/telaria.go
@@ -304,14 +304,15 @@ func (a *TelariaAdapter) MakeBids(internalRequest *openrtb2.BidRequest, external
 	}
 
 	bidResponse := adapters.NewBidderResponseWithBidsCapacity(len(bidResp.SeatBid[0].Bid))
-	sb := bidResp.SeatBid[0]
-
-	for i := range sb.Bid {
-		bid := sb.Bid[i]
-		bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
-			Bid:     &bid,
-			BidType: openrtb_ext.BidTypeVideo,
-		})
+	for j := range bidResp.SeatBid {
+		sb := bidResp.SeatBid[j]
+		for i := range sb.Bid {
+			bid := sb.Bid[i]
+			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+				Bid:     &bid,
+				BidType: openrtb_ext.BidTypeVideo,
+			})
+		}
 	}
 	return bidResponse, nil
 }

--- a/adapters/telaria/telaria.go
+++ b/adapters/telaria/telaria.go
@@ -154,8 +154,36 @@ func (a *TelariaAdapter) MakeRequests(requestIn *openrtb2.BidRequest, reqInfo *a
 
 	originalPublisherID := a.FetchOriginalPublisherID(&request)
 
-	headers := GetHeaders(&request)
-	var requestData []*adapters.RequestData
+	// All imps in a pod share the same seatCode and endpoint: extract them
+	// from the first imp and use them for the single outgoing request.
+	firstImpExt, err := a.FetchTelariaExtImpParams(&request.Imp[0])
+	if err != nil {
+		return nil, []error{err}
+	}
+	if firstImpExt == nil {
+		return nil, []error{&errortypes.BadInput{Message: "Telaria: nil ExtImpTelaria object"}}
+	}
+
+	seatCode := firstImpExt.SeatCode
+
+	if firstImpExt.SspID == "" {
+		firstImpExt.SspID = "ads"
+	}
+	endpoint, err := macros.ResolveMacros(a.endpointTemplate, firstImpExt)
+	if err != nil {
+		return nil, []error{&errortypes.BadInput{Message: fmt.Sprintf("Error resolving macros: %v", err)}}
+	}
+
+	// Add the Extra from the first imp to the top-level request Ext.
+	if firstImpExt.Extra != nil {
+		request.Ext, err = json.Marshal(&telariaBidExt{Extra: firstImpExt.Extra})
+		if err != nil {
+			return nil, []error{err}
+		}
+	}
+
+	// Process every imp: validate, rewrite ext and tagID, convert bidfloor to USD.
+	processedImps := make([]openrtb2.Imp, 0, len(request.Imp))
 	for _, imp := range request.Imp {
 		if imp.Banner != nil {
 			return nil, []error{&errortypes.BadInput{
@@ -168,8 +196,6 @@ func (a *TelariaAdapter) MakeRequests(requestIn *openrtb2.BidRequest, reqInfo *a
 			}}
 		}
 
-		copyRequest := request
-		// fetch adCode & seatCode from imp[i].ext
 		telariaImpExt, err := a.FetchTelariaExtImpParams(&imp)
 		if err != nil {
 			return nil, []error{err}
@@ -178,33 +204,14 @@ func (a *TelariaAdapter) MakeRequests(requestIn *openrtb2.BidRequest, reqInfo *a
 			return nil, []error{&errortypes.BadInput{Message: "Telaria: nil ExtImpTelaria object"}}
 		}
 
-		// move the original tagId and the original publisher.id into the imp[i].ext object
+		// Move the original tagID and publisher ID into imp.ext.
 		imp.Ext, err = json.Marshal(&ImpressionExtOut{imp.TagID, originalPublisherID})
 		if err != nil {
 			return nil, []error{err}
 		}
 
-		seatCode := telariaImpExt.SeatCode
-
-		if telariaImpExt.SspID == "" {
-			telariaImpExt.SspID = "ads"
-		}
-		// resolve the macros in the endpoint template
-		endpoint, err := macros.ResolveMacros(a.endpointTemplate, telariaImpExt)
-		if err != nil {
-			return nil, []error{&errortypes.BadInput{Message: fmt.Sprintf("Error resolving macros: %v", err)}}
-		}
-
-		// Swap the tagID with adCode
+		// Swap tagID with adCode.
 		imp.TagID = telariaImpExt.AdCode
-
-		// Add the Extra from Imp to the top level Ext
-		if telariaImpExt.Extra != nil {
-			copyRequest.Ext, err = json.Marshal(&telariaBidExt{Extra: telariaImpExt.Extra})
-			if err != nil {
-				return nil, []error{err}
-			}
-		}
 
 		resolvedBidFloor, err := resolveBidFloor(imp.BidFloor, imp.BidFloorCur, reqInfo)
 		if err != nil {
@@ -217,26 +224,27 @@ func (a *TelariaAdapter) MakeRequests(requestIn *openrtb2.BidRequest, reqInfo *a
 			imp.BidFloorCur = bidderCurrency
 		}
 
-		copyRequest.Imp = []openrtb2.Imp{imp}
-		// Add seatCode to <Site/App>.Publisher.ID
-		siteObject, appObject := a.PopulatePublisherId(&copyRequest, seatCode)
-
-		copyRequest.Site = siteObject
-		copyRequest.App = appObject
-		reqJSON, err := json.Marshal(copyRequest)
-		if err != nil {
-			return nil, []error{err}
-		}
-		requestData = append(requestData, &adapters.RequestData{
-			Method:  "POST",
-			Uri:     endpoint,
-			Body:    reqJSON,
-			Headers: *headers,
-			ImpIDs:  openrtb_ext.GetImpIDs(copyRequest.Imp),
-		})
+		processedImps = append(processedImps, imp)
 	}
 
-	return requestData, nil
+	// Send all imps in a single request instead of one request per imp.
+	request.Imp = processedImps
+	siteObject, appObject := a.PopulatePublisherId(&request, seatCode)
+	request.Site = siteObject
+	request.App = appObject
+
+	reqJSON, err := json.Marshal(request)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return []*adapters.RequestData{{
+		Method:  "POST",
+		Uri:     endpoint,
+		Body:    reqJSON,
+		Headers: *GetHeaders(&request),
+		ImpIDs:  openrtb_ext.GetImpIDs(request.Imp),
+	}}, nil
 }
 
 // resolveBidFloor function returns converted price for the bidfloor, if the incoming request is not in USD. It's a copy from the 'rubicon' bidder

--- a/adapters/telaria/telariatest/exemplary/multiple-video-web.json
+++ b/adapters/telaria/telariatest/exemplary/multiple-video-web.json
@@ -176,7 +176,12 @@
                       "type": "video"
                     }
                   }
-                },
+                }
+              ],
+              "seat": "telaria"
+            },
+            {
+              "bid": [
                 {
                   "id": "25c6976b14e041029afd5b00acabd933",
                   "impid": "0_1",

--- a/adapters/telaria/telariatest/exemplary/multiple-video-web.json
+++ b/adapters/telaria/telariatest/exemplary/multiple-video-web.json
@@ -116,98 +116,7 @@
                 "originalTagid": "ogTAGID",
                 "originalPublisherid": "123456789"
               }
-            }
-          ],
-          "site": {
-            "page": "test.com",
-            "publisher": {
-              "id": "my-seatcode"
-            }
-          },
-          "user": {
-            "buyeruid": "awesome-user"
-          },
-          "tmax": 1000,
-          "ext": {
-            "extra": {
-              "custom": "1234"
-            }
-          }
-        },
-        "impIDs":["0_0"]
-      },
-      "mockResponse": {
-        "status": 200,
-        "body": {
-          "id": "awesome-resp-id",
-          "seatbid": [
-            {
-              "bid": [
-                {
-                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
-                  "impid": "0_0",
-                  "price": 3.5,
-                  "adm": "awesome-markup",
-                  "adomain": [
-                    "awesome.com"
-                  ],
-                  "crid": "20",
-                  "w": 1280,
-                  "h": 720,
-                  "ext": {
-                    "prebid": {
-                      "type": "video"
-                    }
-                  }
-                }
-              ],
-              "seat": "telaria"
-            }
-          ],
-          "cur": "USD",
-          "ext": {
-            "responsetimemillis": {
-              "telaria": 154
             },
-            "tmaxrequest": 1000
-          }
-        }
-      }
-    },{
-      "expectedRequest": {
-        "headers": {
-          "Content-Type": [
-            "application/json;charset=utf-8"
-          ],
-          "Accept": [
-            "application/json"
-          ],
-          "X-Openrtb-Version": [
-            "2.5"
-          ],
-          "User-Agent": [
-            "test-user-agent"
-          ],
-          "X-Forwarded-For": [
-            "123.123.123.123"
-          ],
-          "Accept-Language": [
-            "en"
-          ],
-          "Dnt": [
-            "0"
-          ]
-        },
-        "uri": "https://ads.tremorhub.com/ad/rtb/prebid",
-        "body": {
-          "id": "some-request-id",
-          "device": {
-            "ua": "test-user-agent",
-            "ip": "123.123.123.123",
-            "language": "en",
-            "dnt": 0
-          },
-          "imp": [
             {
               "id": "0_1",
               "tagid": "my-adcode",
@@ -242,7 +151,7 @@
             }
           }
         },
-        "impIDs":["0_1"]
+        "impIDs": ["0_0", "0_1"]
       },
       "mockResponse": {
         "status": 200,
@@ -251,6 +160,23 @@
           "seatbid": [
             {
               "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "0_0",
+                  "price": 3.5,
+                  "adm": "awesome-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 1280,
+                  "h": 720,
+                  "ext": {
+                    "prebid": {
+                      "type": "video"
+                    }
+                  }
+                },
                 {
                   "id": "25c6976b14e041029afd5b00acabd933",
                   "impid": "0_1",
@@ -285,48 +211,48 @@
   ],
   "expectedBidResponses": [
     {
-      "bids": [{
-        "bid": {
-          "id": "a3ae1b4e2fc24a4fb45540082e98e161",
-          "impid": "0_0",
-          "price": 3.5,
-          "adm": "awesome-markup",
-          "adomain": [
-            "awesome.com"
-          ],
-          "crid": "20",
-          "w": 1280,
-          "h": 720,
-          "ext": {
-            "prebid": {
-              "type": "video"
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "0_0",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "adomain": [
+              "awesome.com"
+            ],
+            "crid": "20",
+            "w": 1280,
+            "h": 720,
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
             }
-          }
+          },
+          "type": "video"
         },
-        "type": "video"
-      }]
-    },
-    {
-      "bids": [{
-        "bid": {
-          "id": "25c6976b14e041029afd5b00acabd933",
-          "impid": "0_1",
-          "price": 3.5,
-          "adm": "awesome-markup",
-          "adomain": [
-            "awesome.com"
-          ],
-          "crid": "20",
-          "w": 1280,
-          "h": 720,
-          "ext": {
-            "prebid": {
-              "type": "video"
+        {
+          "bid": {
+            "id": "25c6976b14e041029afd5b00acabd933",
+            "impid": "0_1",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "adomain": [
+              "awesome.com"
+            ],
+            "crid": "20",
+            "w": 1280,
+            "h": 720,
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
             }
-          }
-        },
-        "type": "video"
-      }]
+          },
+          "type": "video"
+        }
+      ]
     }
   ]
 }

--- a/adapters/telaria/telariatest/exemplary/multiple-vidoe-app.json
+++ b/adapters/telaria/telariatest/exemplary/multiple-vidoe-app.json
@@ -127,105 +127,7 @@
                 "originalTagid": "ogTAGID",
                 "originalPublisherid": "123456789"
               }
-            }
-          ],
-          "app": {
-            "id": "123456789",
-            "name": "Awesome App",
-            "bundle": "com.app.awesome",
-            "domain": "awesomeapp.com",
-            "cat": [
-              "IAB22-1"
-            ],
-            "publisher": {
-              "id": "my-seatcode"
-            }
-          },
-          "user": {
-            "buyeruid": "awesome-user"
-          },
-          "tmax": 1000
-        },
-        "impIDs":["0_0"]
-      },
-      "mockResponse": {
-        "status": 200,
-        "body": {
-          "id": "awesome-resp-id",
-          "seatbid": [
-            {
-              "bid": [
-                {
-                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
-                  "impid": "0_0",
-                  "price": 3.5,
-                  "adm": "awesome-markup",
-                  "adomain": [
-                    "awesome.com"
-                  ],
-                  "crid": "20",
-                  "w": 1280,
-                  "h": 720,
-                  "ext": {
-                    "prebid": {
-                      "type": "video"
-                    }
-                  }
-                }
-              ],
-              "seat": "telaria"
-            }
-          ],
-          "cur": "USD",
-          "ext": {
-            "responsetimemillis": {
-              "telaria": 154
             },
-            "tmaxrequest": 1000
-          }
-        }
-      }
-    },
-    {
-      "expectedRequest": {
-        "headers": {
-          "Content-Type": [
-            "application/json;charset=utf-8"
-          ],
-          "Accept": [
-            "application/json"
-          ],
-          "X-Openrtb-Version": [
-            "2.5"
-          ],
-          "User-Agent": [
-            "test-user-agent"
-          ],
-          "X-Forwarded-For": [
-            "123.123.123.123"
-          ],
-          "Accept-Language": [
-            "en"
-          ],
-          "Dnt": [
-            "0"
-          ]
-        },
-        "uri": "https://ads.tremorhub.com/ad/rtb/prebid",
-        "body": {
-          "id": "some-request-id",
-          "ext": {
-            "extra": {
-              "custom": "1234"
-            }
-          },
-          "device": {
-            "ua": "test-user-agent",
-            "ip": "123.123.123.123",
-            "language": "en",
-            "dnt": 0
-          },
-          "imp": [
             {
               "id": "0_1",
               "video": {
@@ -261,7 +163,7 @@
           },
           "tmax": 1000
         },
-        "impIDs":["0_1"]
+        "impIDs": ["0_0", "0_1"]
       },
       "mockResponse": {
         "status": 200,
@@ -270,6 +172,23 @@
           "seatbid": [
             {
               "bid": [
+                {
+                  "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+                  "impid": "0_0",
+                  "price": 3.5,
+                  "adm": "awesome-markup",
+                  "adomain": [
+                    "awesome.com"
+                  ],
+                  "crid": "20",
+                  "w": 1280,
+                  "h": 720,
+                  "ext": {
+                    "prebid": {
+                      "type": "video"
+                    }
+                  }
+                },
                 {
                   "id": "25c6976b14e041029afd5b00acabd933",
                   "impid": "0_1",
@@ -304,48 +223,48 @@
   ],
   "expectedBidResponses": [
     {
-      "bids": [{
-        "bid": {
-          "id": "a3ae1b4e2fc24a4fb45540082e98e161",
-          "impid": "0_0",
-          "price": 3.5,
-          "adm": "awesome-markup",
-          "adomain": [
-            "awesome.com"
-          ],
-          "crid": "20",
-          "w": 1280,
-          "h": 720,
-          "ext": {
-            "prebid": {
-              "type": "video"
+      "bids": [
+        {
+          "bid": {
+            "id": "a3ae1b4e2fc24a4fb45540082e98e161",
+            "impid": "0_0",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "adomain": [
+              "awesome.com"
+            ],
+            "crid": "20",
+            "w": 1280,
+            "h": 720,
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
             }
-          }
+          },
+          "type": "video"
         },
-        "type": "video"
-      }]
-    },
-    {
-      "bids": [{
-        "bid": {
-          "id": "25c6976b14e041029afd5b00acabd933",
-          "impid": "0_1",
-          "price": 3.5,
-          "adm": "awesome-markup",
-          "adomain": [
-            "awesome.com"
-          ],
-          "crid": "20",
-          "w": 1280,
-          "h": 720,
-          "ext": {
-            "prebid": {
-              "type": "video"
+        {
+          "bid": {
+            "id": "25c6976b14e041029afd5b00acabd933",
+            "impid": "0_1",
+            "price": 3.5,
+            "adm": "awesome-markup",
+            "adomain": [
+              "awesome.com"
+            ],
+            "crid": "20",
+            "w": 1280,
+            "h": 720,
+            "ext": {
+              "prebid": {
+                "type": "video"
+              }
             }
-          }
-        },
-        "type": "video"
-      }]
+          },
+          "type": "video"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Changed telaria.go to make a single request:
before, the loop on `request.Imp` created a separate `RequestData` for each `imp`, so N imps = N HTTP calls to Telaria.

Now: the shared configuration (seatCode, endpoint, Extra) is extracted only once from the first `imp`, then the loop processes all the imps and constructs a single RequestData with all the imps contained within.