### PR TITLE
default release should be patch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ def dockerImageName = "prebid-server"
 def gar_locations = ["us", "europe", "asia"]
 def gar_repo = "viralize-143916/monetize"
 def releaseConfig = [
-    "default_release": "minor"
+    "default_release": "patch"
 ]
 def buildImage(name, dcr) {
     sh """


### PR DESCRIPTION
Major and minor versions should be aligned to the `origin` prebid server version we are using.

We should use only a patch release for the modifications we add.