### PR TITLE
add generic vast bidder

### DIFF
--- a/adapters/genericvast/genericvast.go
+++ b/adapters/genericvast/genericvast.go
@@ -13,7 +13,6 @@ import (
 )
 
 type adapter struct {
-	endpoint string
 }
 
 // impExt is the relevant subset of imp.ext for this adapter: only the
@@ -27,7 +26,7 @@ const defaultCurrency = "EUR"
 
 // Builder builds a new instance of the Generic VAST adapter for the given bidder with the given config.
 func Builder(bidderName openrtb_ext.BidderName, cfg config.Adapter, server config.Server) (adapters.Bidder, error) {
-	return &adapter{endpoint: cfg.Endpoint}, nil
+	return &adapter{}, nil
 }
 
 // MakeRequests issues exactly one GET to the URL declared on imp[0].ext.bidder, regardless of
@@ -119,19 +118,11 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, _ *adapters.RequestData
 		return nil, nil
 	}
 
-	var cpmFallback *float64
+	var perAdFallback float64
 	var ext impExt
 	if err := jsonutil.Unmarshal(request.Imp[0].Ext, &ext); err == nil {
-		cpmFallback = ext.Bidder.CPM
+		perAdFallback = ext.Bidder.CPM / float64(len(doc.Ads))
 	}
-	// The fallback CPM represents the total CPM for the whole VAST response, so
-	// when multiple <Ad> elements are returned we divide it evenly across them.
-	var perAdFallback *float64
-	if cpmFallback != nil && len(doc.Ads) > 0 {
-		v := *cpmFallback / float64(len(doc.Ads))
-		perAdFallback = &v
-	}
-
 	resp := &adapters.BidderResponse{Currency: defaultCurrency, Bids: make([]*adapters.TypedBid, 0, len(doc.Ads))}
 	currencySet := false
 
@@ -140,8 +131,8 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, _ *adapters.RequestData
 		impID := request.Imp[i%len(request.Imp)].ID
 
 		price, currency, ok := extractPrice(ad)
-		if !ok && perAdFallback != nil {
-			price = *perAdFallback
+		if !ok {
+			price = perAdFallback
 			currency = defaultCurrency
 		}
 		if !currencySet && currency != "" {

--- a/adapters/genericvast/genericvast.go
+++ b/adapters/genericvast/genericvast.go
@@ -1,0 +1,173 @@
+package genericvast
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v3/adapters"
+	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/errortypes"
+	"github.com/prebid/prebid-server/v3/openrtb_ext"
+	"github.com/prebid/prebid-server/v3/util/jsonutil"
+)
+
+type adapter struct {
+	endpoint string
+}
+
+// impExt is the relevant subset of imp.ext for this adapter: only the
+// `bidder` block carrying the genericvast params. Decoded in a single
+// jsonutil.Unmarshal pass.
+type impExt struct {
+	Bidder openrtb_ext.ExtImpGenericVast `json:"bidder"`
+}
+
+const defaultCurrency = "EUR"
+
+// Builder builds a new instance of the Generic VAST adapter for the given bidder with the given config.
+func Builder(bidderName openrtb_ext.BidderName, cfg config.Adapter, server config.Server) (adapters.Bidder, error) {
+	return &adapter{endpoint: cfg.Endpoint}, nil
+}
+
+// MakeRequests issues exactly one GET to the URL declared on imp[0].ext.bidder, regardless of
+// the number of impressions in the request. Headers carry forward device/site/user context.
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, _ *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	if len(request.Imp) == 0 {
+		return nil, []error{&errortypes.BadInput{Message: "request contains no impressions"}}
+	}
+
+	var ext impExt
+	err := jsonutil.Unmarshal(request.Imp[0].Ext, &ext)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return []*adapters.RequestData{
+		{
+			Method:  http.MethodGet,
+			Uri:     ext.Bidder.URL,
+			Headers: buildHeaders(request),
+			ImpIDs:  openrtb_ext.GetImpIDs(request.Imp),
+		},
+	}, nil
+}
+
+func buildHeaders(request *openrtb2.BidRequest) http.Header {
+	h := http.Header{}
+	h.Set("Accept", "application/xml, text/xml, */*")
+
+	if request.Device != nil {
+		d := request.Device
+		if d.UA != "" {
+			h.Set("User-Agent", d.UA)
+		}
+		ip := d.IP
+		if ip == "" {
+			ip = d.IPv6
+		}
+		if ip != "" {
+			h.Set("X-Forwarded-For", ip)
+			h.Set("X-Device-IP", ip)
+			h.Set("X-Real-IP", ip)
+		}
+		if d.Language != "" {
+			h.Set("Accept-Language", d.Language)
+			h.Set("X-Device-Language", d.Language)
+		}
+		if d.DNT != nil {
+			h.Set("DNT", fmt.Sprintf("%d", *d.DNT))
+		}
+	}
+
+	if request.Site != nil {
+		ref := request.Site.Page
+		if ref == "" {
+			ref = request.Site.Ref
+		}
+		if ref != "" {
+			h.Set("Referer", ref)
+			h.Set("X-Device-Referer", ref)
+		}
+	}
+
+	return h
+}
+
+// MakeBids parses a VAST response and emits one bid per <Ad> element. Ads are mapped to the
+// request's imp IDs positionally with wrap-around: Ad[i] -> imp[i % N].
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, _ *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if response.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, []error{&errortypes.BadServerResponse{
+			Message: fmt.Sprintf("unexpected status code: %d", response.StatusCode),
+		}}
+	}
+
+	if len(response.Body) == 0 {
+		return nil, nil
+	}
+
+	doc, err := parseVAST(response.Body)
+	if err != nil {
+		return nil, []error{&errortypes.BadServerResponse{
+			Message: fmt.Sprintf("failed to parse VAST response: %v", err),
+		}}
+	}
+	if len(doc.Ads) == 0 {
+		return nil, nil
+	}
+
+	var cpmFallback *float64
+	var ext impExt
+	if err := jsonutil.Unmarshal(request.Imp[0].Ext, &ext); err == nil {
+		cpmFallback = ext.Bidder.CPM
+	}
+	// The fallback CPM represents the total CPM for the whole VAST response, so
+	// when multiple <Ad> elements are returned we divide it evenly across them.
+	var perAdFallback *float64
+	if cpmFallback != nil && len(doc.Ads) > 0 {
+		v := *cpmFallback / float64(len(doc.Ads))
+		perAdFallback = &v
+	}
+
+	resp := &adapters.BidderResponse{Currency: defaultCurrency, Bids: make([]*adapters.TypedBid, 0, len(doc.Ads))}
+	currencySet := false
+
+	for i := range doc.Ads {
+		ad := &doc.Ads[i]
+		impID := request.Imp[i%len(request.Imp)].ID
+
+		price, currency, ok := extractPrice(ad)
+		if !ok && perAdFallback != nil {
+			price = *perAdFallback
+			currency = defaultCurrency
+		}
+		if !currencySet && currency != "" {
+			resp.Currency = currency
+			currencySet = true
+		}
+
+		bidID := ad.ID
+		if bidID == "" {
+			bidID = fmt.Sprintf("genericvast-%s-%d", impID, i)
+		}
+
+		resp.Bids = append(resp.Bids, &adapters.TypedBid{
+			BidType: openrtb_ext.BidTypeVideo,
+			Bid: &openrtb2.Bid{
+				ID:      bidID,
+				ImpID:   impID,
+				Price:   price,
+				AdM:     reemitAd(doc.Version, ad),
+				CrID:    extractCreativeID(ad),
+				Dur:     extractDurationSeconds(ad),
+				ADomain: extractAdDomains(ad),
+				MType:   openrtb2.MarkupVideo,
+			},
+		})
+	}
+
+	return resp, nil
+}

--- a/adapters/genericvast/genericvast_test.go
+++ b/adapters/genericvast/genericvast_test.go
@@ -1,0 +1,61 @@
+package genericvast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v3/adapters"
+	"github.com/prebid/prebid-server/v3/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/openrtb_ext"
+)
+
+func TestJsonSamples(t *testing.T) {
+	bidder, err := Builder(openrtb_ext.BidderGenericVast, config.Adapter{
+		Endpoint: "https://example.com/genericvast",
+	}, config.Server{})
+	if err != nil {
+		t.Fatalf("Builder returned unexpected error %v", err)
+	}
+
+	adapterstest.RunJSONBidderTest(t, "genericvasttest", &xmlBodyBidder{Bidder: bidder})
+}
+
+// xmlBodyBidder wraps a real Bidder for the JSON-fixture test harness. Real
+// genericvast servers respond with raw XML, but the standard harness stores
+// httpResponse.body as a JSON-encoded string (json.RawMessage keeps the
+// surrounding quotes). This wrapper unwraps that JSON string before delegating
+// to MakeBids, so the production adapter can assume raw XML on the wire.
+type xmlBodyBidder struct {
+	adapters.Bidder
+}
+
+func (b *xmlBodyBidder) MakeBids(req *openrtb2.BidRequest, ext *adapters.RequestData, resp *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if resp != nil {
+		resp = &adapters.ResponseData{
+			StatusCode: resp.StatusCode,
+			Body:       unwrapJSONStringBody(resp.Body),
+			Headers:    resp.Headers,
+		}
+	}
+	return b.Bidder.MakeBids(req, ext, resp)
+}
+
+// unwrapJSONStringBody decodes a JSON-encoded string body produced by the JSON
+// test-fixture harness back into its raw XML bytes. Non-JSON-string inputs
+// (which is what a real bidder would send) are returned unchanged.
+func unwrapJSONStringBody(body []byte) []byte {
+	trimmed := body
+	for len(trimmed) > 0 && (trimmed[0] == ' ' || trimmed[0] == '\t' || trimmed[0] == '\r' || trimmed[0] == '\n') {
+		trimmed = trimmed[1:]
+	}
+	if len(trimmed) == 0 || trimmed[0] != '"' {
+		return body
+	}
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err != nil {
+		return body
+	}
+	return []byte(s)
+}

--- a/adapters/genericvast/genericvast_test.go
+++ b/adapters/genericvast/genericvast_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func TestJsonSamples(t *testing.T) {
-	bidder, err := Builder(openrtb_ext.BidderGenericVast, config.Adapter{
-		Endpoint: "https://example.com/genericvast",
-	}, config.Server{})
+	bidder, err := Builder(openrtb_ext.BidderGenericVast, config.Adapter{}, config.Server{})
 	if err != nil {
 		t.Fatalf("Builder returned unexpected error %v", err)
 	}

--- a/adapters/genericvast/genericvasttest/exemplary/app-request.json
+++ b/adapters/genericvast/genericvasttest/exemplary/app-request.json
@@ -1,0 +1,63 @@
+{
+  "mockBidRequest": {
+    "id": "req-app",
+    "app": {
+      "id": "app-1",
+      "bundle": "com.example.app",
+      "name": "Example App"
+    },
+    "device": {
+      "ua": "ExampleApp/1.0 (iPhone)",
+      "ip": "198.51.100.7",
+      "language": "fr"
+    },
+    "imp": [
+      {
+        "id": "imp-app",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/app"}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/app",
+        "headers": {
+          "Accept": ["application/xml, text/xml, */*"],
+          "User-Agent": ["ExampleApp/1.0 (iPhone)"],
+          "X-Forwarded-For": ["198.51.100.7"],
+          "X-Device-Ip": ["198.51.100.7"],
+          "X-Real-Ip": ["198.51.100.7"],
+          "Accept-Language": ["fr"],
+          "X-Device-Language": ["fr"]
+        },
+        "impIDs": ["imp-app"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"4.0\"><Ad id=\"app-ad\"><InLine><AdSystem>AppSSP</AdSystem><Advertiser>brand-app.example.com</Advertiser><Pricing currency=\"EUR\">0.5</Pricing><Creatives><Creative id=\"c-app\"><Linear><Duration>00:00:06.500</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "app-ad",
+            "impid": "imp-app",
+            "price": 0.5,
+            "adm": "<VAST version=\"4.0\"><Ad id=\"app-ad\"><InLine><AdSystem>AppSSP</AdSystem><Advertiser>brand-app.example.com</Advertiser><Pricing currency=\"EUR\">0.5</Pricing><Creatives><Creative id=\"c-app\"><Linear><Duration>00:00:06.500</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "c-app",
+            "dur": 7,
+            "adomain": ["brand-app.example.com"],
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/genericvast/genericvasttest/exemplary/cpm-fallback.json
+++ b/adapters/genericvast/genericvasttest/exemplary/cpm-fallback.json
@@ -1,0 +1,44 @@
+{
+  "mockBidRequest": {
+    "id": "req-cpm",
+    "site": {"page": "https://publisher.example.com/"},
+    "imp": [
+      {
+        "id": "imp-cpm",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/no-pricing", "cpm": 1.5}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/no-pricing",
+        "impIDs": ["imp-cpm"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"3.0\"><Ad id=\"ad-np\"><InLine><AdSystem>no-pricing-here</AdSystem><Creatives><Creative id=\"c-np\"><Linear><Duration>00:00:10</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "ad-np",
+            "impid": "imp-cpm",
+            "price": 1.5,
+            "adm": "<VAST version=\"3.0\"><Ad id=\"ad-np\"><InLine><AdSystem>no-pricing-here</AdSystem><Creatives><Creative id=\"c-np\"><Linear><Duration>00:00:10</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "c-np",
+            "dur": 10,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/genericvast/genericvasttest/exemplary/multi-ad-multi-imp.json
+++ b/adapters/genericvast/genericvasttest/exemplary/multi-ad-multi-imp.json
@@ -1,0 +1,82 @@
+{
+  "mockBidRequest": {
+    "id": "req-multi",
+    "site": {
+      "page": "https://publisher.example.com/page"
+    },
+    "imp": [
+      {
+        "id": "imp-1",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/tag?n=3"}}
+      },
+      {
+        "id": "imp-2",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://ignored.example.com/should-not-be-used"}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/tag?n=3",
+        "headers": {
+          "Accept": ["application/xml, text/xml, */*"],
+          "Referer": ["https://publisher.example.com/page"],
+          "X-Device-Referer": ["https://publisher.example.com/page"]
+        },
+        "impIDs": ["imp-1", "imp-2"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"3.0\"><Ad id=\"ad-A\"><InLine><AdSystem>AdsysOne</AdSystem><Advertiser>brand-a.example.com</Advertiser><Pricing currency=\"EUR\">1.10</Pricing><Creatives><Creative id=\"c-A\"><Linear><Duration>00:00:15</Duration></Linear></Creative></Creatives></InLine></Ad><Ad id=\"ad-B\"><InLine><AdSystem>AdsysOne</AdSystem><Advertiser>brand-b.example.com</Advertiser><Pricing currency=\"EUR\">2.20</Pricing><Creatives><Creative id=\"c-B\"><Linear><Duration>00:00:20</Duration></Linear></Creative></Creatives></InLine></Ad><Ad id=\"ad-C\"><InLine><AdSystem>AdsysOne</AdSystem><Pricing currency=\"EUR\">3.30</Pricing><Creatives><Creative id=\"c-C\"><Linear><Duration>00:00:25</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "ad-A",
+            "impid": "imp-1",
+            "price": 1.1,
+            "adm": "<VAST version=\"3.0\"><Ad id=\"ad-A\"><InLine><AdSystem>AdsysOne</AdSystem><Advertiser>brand-a.example.com</Advertiser><Pricing currency=\"EUR\">1.10</Pricing><Creatives><Creative id=\"c-A\"><Linear><Duration>00:00:15</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "c-A",
+            "dur": 15,
+            "adomain": ["brand-a.example.com"],
+            "mtype": 2
+          },
+          "type": "video"
+        },
+        {
+          "bid": {
+            "id": "ad-B",
+            "impid": "imp-2",
+            "price": 2.2,
+            "adm": "<VAST version=\"3.0\"><Ad id=\"ad-B\"><InLine><AdSystem>AdsysOne</AdSystem><Advertiser>brand-b.example.com</Advertiser><Pricing currency=\"EUR\">2.20</Pricing><Creatives><Creative id=\"c-B\"><Linear><Duration>00:00:20</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "c-B",
+            "dur": 20,
+            "adomain": ["brand-b.example.com"],
+            "mtype": 2
+          },
+          "type": "video"
+        },
+        {
+          "bid": {
+            "id": "ad-C",
+            "impid": "imp-1",
+            "price": 3.3,
+            "adm": "<VAST version=\"3.0\"><Ad id=\"ad-C\"><InLine><AdSystem>AdsysOne</AdSystem><Pricing currency=\"EUR\">3.30</Pricing><Creatives><Creative id=\"c-C\"><Linear><Duration>00:00:25</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "c-C",
+            "dur": 25,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/genericvast/genericvasttest/exemplary/simple-video.json
+++ b/adapters/genericvast/genericvasttest/exemplary/simple-video.json
@@ -1,0 +1,75 @@
+{
+  "mockBidRequest": {
+    "id": "req-1",
+    "site": {
+      "id": "site-1",
+      "page": "https://publisher.example.com/article",
+      "publisher": {"id": "pub-1"}
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "ip": "203.0.113.5",
+      "language": "en-US",
+      "dnt": 0
+    },
+    "imp": [
+      {
+        "id": "imp-1",
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 360
+        },
+        "ext": {
+          "bidder": {
+            "url": "https://vast.example.com/tag?impid=imp-1"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/tag?impid=imp-1",
+        "headers": {
+          "Accept": ["application/xml, text/xml, */*"],
+          "User-Agent": ["Mozilla/5.0"],
+          "X-Forwarded-For": ["203.0.113.5"],
+          "X-Device-Ip": ["203.0.113.5"],
+          "X-Real-Ip": ["203.0.113.5"],
+          "Accept-Language": ["en-US"],
+          "X-Device-Language": ["en-US"],
+          "Dnt": ["0"],
+          "Referer": ["https://publisher.example.com/article"],
+          "X-Device-Referer": ["https://publisher.example.com/article"]
+        },
+        "impIDs": ["imp-1"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"4.0\"><Ad id=\"ad-1\"><InLine><AdSystem>VastExampleSSP</AdSystem><Advertiser>brand.example.com</Advertiser><Pricing model=\"cpm\" currency=\"USD\">2.50</Pricing><Creatives><Creative id=\"creative-1\"><Linear><Duration>00:00:30</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "ad-1",
+            "impid": "imp-1",
+            "price": 2.5,
+            "adm": "<VAST version=\"4.0\"><Ad id=\"ad-1\"><InLine><AdSystem>VastExampleSSP</AdSystem><Advertiser>brand.example.com</Advertiser><Pricing model=\"cpm\" currency=\"USD\">2.50</Pricing><Creatives><Creative id=\"creative-1\"><Linear><Duration>00:00:30</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "creative-1",
+            "dur": 30,
+            "adomain": ["brand.example.com"],
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/genericvast/genericvasttest/exemplary/wrapper-ad.json
+++ b/adapters/genericvast/genericvasttest/exemplary/wrapper-ad.json
@@ -1,0 +1,44 @@
+{
+  "mockBidRequest": {
+    "id": "req-wrapper",
+    "site": {"page": "https://publisher.example.com/"},
+    "imp": [
+      {
+        "id": "imp-w",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/wrapper"}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/wrapper",
+        "impIDs": ["imp-w"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"4.2\"><Ad id=\"wrap-1\"><Wrapper><AdSystem>WrapSSP</AdSystem><Advertiser>brand-wrap.example.com</Advertiser><VASTAdTagURI><![CDATA[https://downstream.example.com/vast.xml]]></VASTAdTagURI><Pricing currency=\"EUR\">0.75</Pricing><Creatives><Creative id=\"wc-1\"/></Creatives></Wrapper></Ad></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "wrap-1",
+            "impid": "imp-w",
+            "price": 0.75,
+            "adm": "<VAST version=\"4.2\"><Ad id=\"wrap-1\"><Wrapper><AdSystem>WrapSSP</AdSystem><Advertiser>brand-wrap.example.com</Advertiser><VASTAdTagURI><![CDATA[https://downstream.example.com/vast.xml]]></VASTAdTagURI><Pricing currency=\"EUR\">0.75</Pricing><Creatives><Creative id=\"wc-1\"/></Creatives></Wrapper></Ad></VAST>",
+            "crid": "wc-1",
+            "adomain": ["brand-wrap.example.com"],
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/genericvast/genericvasttest/supplemental/204-no-content.json
+++ b/adapters/genericvast/genericvasttest/supplemental/204-no-content.json
@@ -6,7 +6,7 @@
       {
         "id": "imp-204",
         "video": {"mimes": ["video/mp4"]},
-        "ext": {"bidder": {"url": "https://vast.example.com/empty"}}
+        "ext": {"bidder": {"url": "https://vast.example.com/empty", "cpm": 1.0}}
       }
     ]
   },

--- a/adapters/genericvast/genericvasttest/supplemental/204-no-content.json
+++ b/adapters/genericvast/genericvasttest/supplemental/204-no-content.json
@@ -1,0 +1,26 @@
+{
+  "mockBidRequest": {
+    "id": "req-204",
+    "site": {"page": "https://publisher.example.com/"},
+    "imp": [
+      {
+        "id": "imp-204",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/empty"}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/empty",
+        "impIDs": ["imp-204"]
+      },
+      "mockResponse": {
+        "status": 204,
+        "body": ""
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/genericvast/genericvasttest/supplemental/cpm-fallback-split.json
+++ b/adapters/genericvast/genericvasttest/supplemental/cpm-fallback-split.json
@@ -1,0 +1,56 @@
+{
+  "mockBidRequest": {
+    "id": "req-fb-split",
+    "site": {"page": "https://publisher.example.com/"},
+    "imp": [
+      {
+        "id": "imp-fb",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/multi-no-pricing", "cpm": 3.0}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/multi-no-pricing",
+        "impIDs": ["imp-fb"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"3.0\"><Ad id=\"ad-x\"><InLine><AdSystem>SSP</AdSystem><Creatives><Creative id=\"c-x\"><Linear><Duration>00:00:10</Duration></Linear></Creative></Creatives></InLine></Ad><Ad id=\"ad-y\"><InLine><AdSystem>SSP</AdSystem><Creatives><Creative id=\"c-y\"><Linear><Duration>00:00:15</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "ad-x",
+            "impid": "imp-fb",
+            "price": 1.5,
+            "adm": "<VAST version=\"3.0\"><Ad id=\"ad-x\"><InLine><AdSystem>SSP</AdSystem><Creatives><Creative id=\"c-x\"><Linear><Duration>00:00:10</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "c-x",
+            "dur": 10,
+            "mtype": 2
+          },
+          "type": "video"
+        },
+        {
+          "bid": {
+            "id": "ad-y",
+            "impid": "imp-fb",
+            "price": 1.5,
+            "adm": "<VAST version=\"3.0\"><Ad id=\"ad-y\"><InLine><AdSystem>SSP</AdSystem><Creatives><Creative id=\"c-y\"><Linear><Duration>00:00:15</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "c-y",
+            "dur": 15,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/genericvast/genericvasttest/supplemental/empty-vast.json
+++ b/adapters/genericvast/genericvasttest/supplemental/empty-vast.json
@@ -6,7 +6,7 @@
       {
         "id": "imp-ev",
         "video": {"mimes": ["video/mp4"]},
-        "ext": {"bidder": {"url": "https://vast.example.com/no-ads"}}
+        "ext": {"bidder": {"url": "https://vast.example.com/no-ads", "cpm": 1.0}}
       }
     ]
   },

--- a/adapters/genericvast/genericvasttest/supplemental/empty-vast.json
+++ b/adapters/genericvast/genericvasttest/supplemental/empty-vast.json
@@ -1,0 +1,26 @@
+{
+  "mockBidRequest": {
+    "id": "req-empty-vast",
+    "site": {"page": "https://publisher.example.com/"},
+    "imp": [
+      {
+        "id": "imp-ev",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/no-ads"}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/no-ads",
+        "impIDs": ["imp-ev"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"4.0\"><Error><![CDATA[https://errors.example.com/nofill]]></Error></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/genericvast/genericvasttest/supplemental/invalid-xml.json
+++ b/adapters/genericvast/genericvasttest/supplemental/invalid-xml.json
@@ -1,0 +1,31 @@
+{
+  "mockBidRequest": {
+    "id": "req-bad-xml",
+    "site": {"page": "https://publisher.example.com/"},
+    "imp": [
+      {
+        "id": "imp-bad",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/bad-xml"}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/bad-xml",
+        "impIDs": ["imp-bad"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"4.0\"><Ad><InLine><AdSystem>oops"
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "failed to parse VAST response",
+      "comparison": "regex"
+    }
+  ]
+}

--- a/adapters/genericvast/genericvasttest/supplemental/invalid-xml.json
+++ b/adapters/genericvast/genericvasttest/supplemental/invalid-xml.json
@@ -6,7 +6,7 @@
       {
         "id": "imp-bad",
         "video": {"mimes": ["video/mp4"]},
-        "ext": {"bidder": {"url": "https://vast.example.com/bad-xml"}}
+        "ext": {"bidder": {"url": "https://vast.example.com/bad-xml", "cpm": 1.0}}
       }
     ]
   },

--- a/adapters/genericvast/genericvasttest/supplemental/non-200-error.json
+++ b/adapters/genericvast/genericvasttest/supplemental/non-200-error.json
@@ -6,7 +6,7 @@
       {
         "id": "imp-500",
         "video": {"mimes": ["video/mp4"]},
-        "ext": {"bidder": {"url": "https://vast.example.com/error"}}
+        "ext": {"bidder": {"url": "https://vast.example.com/error", "cpm": 1.0}}
       }
     ]
   },

--- a/adapters/genericvast/genericvasttest/supplemental/non-200-error.json
+++ b/adapters/genericvast/genericvasttest/supplemental/non-200-error.json
@@ -1,0 +1,31 @@
+{
+  "mockBidRequest": {
+    "id": "req-500",
+    "site": {"page": "https://publisher.example.com/"},
+    "imp": [
+      {
+        "id": "imp-500",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/error"}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/error",
+        "impIDs": ["imp-500"]
+      },
+      "mockResponse": {
+        "status": 500,
+        "body": ""
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "unexpected status code: 500",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/genericvast/genericvasttest/supplemental/non-cpm-pricing-model.json
+++ b/adapters/genericvast/genericvasttest/supplemental/non-cpm-pricing-model.json
@@ -1,0 +1,44 @@
+{
+  "mockBidRequest": {
+    "id": "req-cpc",
+    "site": {"page": "https://publisher.example.com/"},
+    "imp": [
+      {
+        "id": "imp-cpc",
+        "video": {"mimes": ["video/mp4"]},
+        "ext": {"bidder": {"url": "https://vast.example.com/cpc", "cpm": 2.0}}
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/cpc",
+        "impIDs": ["imp-cpc"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"4.0\"><Ad id=\"ad-cpc\"><InLine><AdSystem>SomeSSP</AdSystem><Pricing model=\"CPC\" currency=\"USD\">9.99</Pricing><Creatives><Creative id=\"c-cpc\"><Linear><Duration>00:00:10</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": [
+        {
+          "bid": {
+            "id": "ad-cpc",
+            "impid": "imp-cpc",
+            "price": 2.0,
+            "adm": "<VAST version=\"4.0\"><Ad id=\"ad-cpc\"><InLine><AdSystem>SomeSSP</AdSystem><Pricing model=\"CPC\" currency=\"USD\">9.99</Pricing><Creatives><Creative id=\"c-cpc\"><Linear><Duration>00:00:10</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "c-cpc",
+            "dur": 10,
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/genericvast/vast.go
+++ b/adapters/genericvast/vast.go
@@ -1,0 +1,221 @@
+package genericvast
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// vastDoc is the minimal VAST document we decode. Unknown elements are tolerated.
+type vastDoc struct {
+	XMLName xml.Name `xml:"VAST"`
+	Version string   `xml:"version,attr"`
+	Ads     []vastAd `xml:"Ad"`
+}
+
+// vastAd captures the <Ad> element. InnerXML is preserved so that we can
+// re-emit the original ad (including unknown extensions) verbatim per bid.
+type vastAd struct {
+	ID       string       `xml:"id,attr,omitempty"`
+	Sequence string       `xml:"sequence,attr,omitempty"`
+	InnerXML string       `xml:",innerxml"`
+	InLine   *vastInLine  `xml:"InLine,omitempty"`
+	Wrapper  *vastWrapper `xml:"Wrapper,omitempty"`
+}
+
+type vastInLine struct {
+	AdSystem   string        `xml:"AdSystem"`
+	Advertiser string        `xml:"Advertiser"`
+	Pricing    *vastPricing  `xml:"Pricing,omitempty"`
+	Creatives  vastCreatives `xml:"Creatives"`
+}
+
+type vastWrapper struct {
+	AdSystem   string        `xml:"AdSystem"`
+	Advertiser string        `xml:"Advertiser"`
+	Pricing    *vastPricing  `xml:"Pricing,omitempty"`
+	Creatives  vastCreatives `xml:"Creatives"`
+}
+
+type vastPricing struct {
+	Currency string `xml:"currency,attr"`
+	Model    string `xml:"model,attr"`
+	Value    string `xml:",chardata"`
+}
+
+type vastCreatives struct {
+	Creative []vastCreative `xml:"Creative"`
+}
+
+type vastCreative struct {
+	ID     string      `xml:"id,attr"`
+	Linear *vastLinear `xml:"Linear,omitempty"`
+}
+
+type vastLinear struct {
+	Duration string `xml:"Duration"`
+}
+
+// parseVAST decodes the VAST document. Leading whitespace, BOM, and XML
+// declaration are accepted; unknown elements are ignored.
+func parseVAST(body []byte) (*vastDoc, error) {
+	dec := xml.NewDecoder(bytes.NewReader(body))
+	dec.Strict = false
+	var doc vastDoc
+	if err := dec.Decode(&doc); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+// advertiserValue returns the <Advertiser> text from an InLine or Wrapper, whichever is set.
+func (a *vastAd) advertiserValue() string {
+	switch {
+	case a.InLine != nil:
+		return strings.TrimSpace(a.InLine.Advertiser)
+	case a.Wrapper != nil:
+		return strings.TrimSpace(a.Wrapper.Advertiser)
+	}
+	return ""
+}
+
+// pricing returns the first non-empty <Pricing> from InLine/Wrapper.
+func (a *vastAd) pricing() *vastPricing {
+	if a.InLine != nil && a.InLine.Pricing != nil {
+		return a.InLine.Pricing
+	}
+	if a.Wrapper != nil && a.Wrapper.Pricing != nil {
+		return a.Wrapper.Pricing
+	}
+	return nil
+}
+
+// creatives returns InLine or Wrapper creatives.
+func (a *vastAd) creatives() []vastCreative {
+	if a.InLine != nil {
+		return a.InLine.Creatives.Creative
+	}
+	if a.Wrapper != nil {
+		return a.Wrapper.Creatives.Creative
+	}
+	return nil
+}
+
+// extractPrice returns (price, currency, ok). Only <Pricing model="CPM"> is honored;
+// other models (CPC/CPE/CPV) are ignored so the caller can fall back to the configured
+// CPM. An empty model attribute is treated as CPM for backward compatibility with
+// VAST 3 responses that omit the attribute.
+func extractPrice(ad *vastAd) (float64, string, bool) {
+	p := ad.pricing()
+	if p == nil {
+		return 0, "", false
+	}
+	model := strings.TrimSpace(p.Model)
+	if model != "" && !strings.EqualFold(model, "CPM") {
+		return 0, "", false
+	}
+	value := strings.TrimSpace(p.Value)
+	if value == "" {
+		return 0, p.Currency, false
+	}
+	price, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, p.Currency, false
+	}
+	return price, p.Currency, true
+}
+
+// extractCreativeID returns the first Creative@id, or empty.
+func extractCreativeID(ad *vastAd) string {
+	for _, c := range ad.creatives() {
+		if c.ID != "" {
+			return c.ID
+		}
+	}
+	return ""
+}
+
+// extractDurationSeconds parses Linear/Duration in HH:MM:SS[.fff] and returns
+// rounded seconds. Returns 0 if absent or unparsable.
+func extractDurationSeconds(ad *vastAd) int64 {
+	for _, c := range ad.creatives() {
+		if c.Linear == nil {
+			continue
+		}
+		d := strings.TrimSpace(c.Linear.Duration)
+		if d == "" {
+			continue
+		}
+		if secs, ok := parseDurationHMS(d); ok {
+			return secs
+		}
+	}
+	return 0
+}
+
+func parseDurationHMS(s string) (int64, bool) {
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) != 3 {
+		return 0, false
+	}
+	h, err := strconv.Atoi(parts[0])
+	if err != nil || h < 0 {
+		return 0, false
+	}
+	m, err := strconv.Atoi(parts[1])
+	if err != nil || m < 0 || m > 59 {
+		return 0, false
+	}
+	secStr := parts[2]
+	// allow fractional seconds
+	secFloat, err := strconv.ParseFloat(secStr, 64)
+	if err != nil || secFloat < 0 {
+		return 0, false
+	}
+	total := int64(h)*3600 + int64(m)*60 + int64(secFloat+0.5)
+	return total, true
+}
+
+// extractAdDomains returns []string{advertiser} when the VAST <Advertiser> field
+// looks like a domain (contains a dot and no whitespace). Otherwise returns nil.
+// Per IAB VAST 4, <Advertiser> carries the advertiser's identity (commonly a domain),
+// while <AdSystem> identifies the ad-serving system and is not appropriate for ADomain.
+func extractAdDomains(ad *vastAd) []string {
+	s := ad.advertiserValue()
+	if s == "" {
+		return nil
+	}
+	if strings.ContainsAny(s, " \t\r\n") {
+		return nil
+	}
+	if !strings.Contains(s, ".") {
+		return nil
+	}
+	return []string{s}
+}
+
+// reemitAd builds a minimal `<VAST version="X"><Ad ...>{inner}</Ad></VAST>`
+// envelope around a single ad, preserving its raw inner XML.
+func reemitAd(version string, ad *vastAd) string {
+	if version == "" {
+		version = "4.0"
+	}
+	var attrs strings.Builder
+	if ad.ID != "" {
+		fmt.Fprintf(&attrs, ` id="%s"`, xmlAttrEscape(ad.ID))
+	}
+	if ad.Sequence != "" {
+		fmt.Fprintf(&attrs, ` sequence="%s"`, xmlAttrEscape(ad.Sequence))
+	}
+	return fmt.Sprintf(`<VAST version="%s"><Ad%s>%s</Ad></VAST>`,
+		xmlAttrEscape(version), attrs.String(), ad.InnerXML)
+}
+
+// xmlAttrEscape escapes characters that would break an XML double-quoted attribute.
+func xmlAttrEscape(s string) string {
+	var b bytes.Buffer
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -115,6 +115,7 @@ import (
 	"github.com/prebid/prebid-server/v3/adapters/fwssp"
 	"github.com/prebid/prebid-server/v3/adapters/gamma"
 	"github.com/prebid/prebid-server/v3/adapters/gamoshi"
+	"github.com/prebid/prebid-server/v3/adapters/genericvast"
 	"github.com/prebid/prebid-server/v3/adapters/globalsun"
 	"github.com/prebid/prebid-server/v3/adapters/goldbach"
 	"github.com/prebid/prebid-server/v3/adapters/gothamads"
@@ -386,6 +387,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderFRVRAdNetwork:     frvradn.Builder,
 		openrtb_ext.BidderGamma:             gamma.Builder,
 		openrtb_ext.BidderGamoshi:           gamoshi.Builder,
+		openrtb_ext.BidderGenericVast:       genericvast.Builder,
 		openrtb_ext.BidderGlobalsun:         globalsun.Builder,
 		openrtb_ext.BidderGoldbach:          goldbach.Builder,
 		openrtb_ext.BidderGothamads:         gothamads.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -132,6 +132,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderFRVRAdNetwork,
 	BidderGamma,
 	BidderGamoshi,
+	BidderGenericVast,
 	BidderGlobalsun,
 	BidderGoldbach,
 	BidderGothamads,
@@ -509,6 +510,7 @@ const (
 	BidderFRVRAdNetwork     BidderName = "frvradn"
 	BidderGamma             BidderName = "gamma"
 	BidderGamoshi           BidderName = "gamoshi"
+	BidderGenericVast       BidderName = "genericvast"
 	BidderGlobalsun         BidderName = "globalsun"
 	BidderGoldbach          BidderName = "goldbach"
 	BidderGothamads         BidderName = "gothamads"

--- a/openrtb_ext/imp_genericvast.go
+++ b/openrtb_ext/imp_genericvast.go
@@ -2,6 +2,6 @@ package openrtb_ext
 
 // ExtImpGenericVast defines the contract for bidrequest.imp[i].ext.prebid.bidder.genericvast.
 type ExtImpGenericVast struct {
-	URL string   `json:"url"`
-	CPM *float64 `json:"cpm,omitempty"`
+	URL string  `json:"url"`
+	CPM float64 `json:"cpm"`
 }

--- a/openrtb_ext/imp_genericvast.go
+++ b/openrtb_ext/imp_genericvast.go
@@ -1,0 +1,7 @@
+package openrtb_ext
+
+// ExtImpGenericVast defines the contract for bidrequest.imp[i].ext.prebid.bidder.genericvast.
+type ExtImpGenericVast struct {
+	URL string   `json:"url"`
+	CPM *float64 `json:"cpm,omitempty"`
+}

--- a/static/bidder-info/genericvast.yaml
+++ b/static/bidder-info/genericvast.yaml
@@ -1,0 +1,12 @@
+endpoint: "https://example.com/genericvast"
+maintainer:
+  email: tech@showheroes.com
+openrtb:
+  version: 2.6
+capabilities:
+  app:
+    mediaTypes:
+      - video
+  site:
+    mediaTypes:
+      - video

--- a/static/bidder-params/genericvast.json
+++ b/static/bidder-params/genericvast.json
@@ -12,7 +12,7 @@
     },
     "cpm": {
       "type": "number",
-      "description": "Fallback CPM (EUR) used only when the VAST response does not declare a <Pricing> element.",
+      "description": "Fallback CPM (EUR) used only when the VAST response does not declare a CPM <Pricing> element.",
       "minimum": 0
     }
   },

--- a/static/bidder-params/genericvast.json
+++ b/static/bidder-params/genericvast.json
@@ -12,9 +12,9 @@
     },
     "cpm": {
       "type": "number",
-      "description": "Optional fallback CPM (EUR) used only when the VAST response does not declare a <Pricing> element.",
+      "description": "Fallback CPM (EUR) used only when the VAST response does not declare a <Pricing> element.",
       "minimum": 0
     }
   },
-  "required": ["url"]
+  "required": ["url", "cpm"]
 }

--- a/static/bidder-params/genericvast.json
+++ b/static/bidder-params/genericvast.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Generic VAST Adapter Params",
+  "description": "A schema which validates params accepted by the Generic VAST adapter",
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "description": "The full URL the adapter will call (verbatim) to fetch a VAST response.",
+      "format": "uri",
+      "minLength": 1
+    },
+    "cpm": {
+      "type": "number",
+      "description": "Optional fallback CPM (EUR) used only when the VAST response does not declare a <Pricing> element.",
+      "minimum": 0
+    }
+  },
+  "required": ["url"]
+}


### PR DESCRIPTION
JIRA ISSUE: https://showheroes.atlassian.net/browse/PLT-4762 

Add a `genericvast` bidder with params:
- url
- cpm

Then PBS will call that `url` to try to get the VAST response. If it's successful, PBS will construct a openRTB response for it.

Bidder also has optional `cpm` param that is used if the `VAST` response doesn't have the `<Pricing>` element.

In case of the structured ad podding, it's assumed that the sender (adserver) creates a proper URL with `maxseq` macro replaced. In that case PBS still sends 1 request, but if the response contains multiple `<Ads>` elements, PBS will create multiple openRTB bids.