### PR TITLE
encode query params before sending http request

### DIFF
--- a/adapters/genericvast/genericvast.go
+++ b/adapters/genericvast/genericvast.go
@@ -3,6 +3,8 @@ package genericvast
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/prebid/openrtb/v20/openrtb2"
 	"github.com/prebid/prebid-server/v3/adapters"
@@ -41,14 +43,42 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, _ *adapters.ExtraRe
 	if err != nil {
 		return nil, []error{err}
 	}
+
+	uri, err := encodeURL(ext.Bidder.URL)
+	if err != nil {
+		return nil, []error{err}
+	}
 	return []*adapters.RequestData{
 		{
 			Method:  http.MethodGet,
-			Uri:     ext.Bidder.URL,
+			Uri:     uri,
 			Headers: buildHeaders(request),
 			ImpIDs:  openrtb_ext.GetImpIDs(request.Imp),
 		},
 	}, nil
+}
+
+// encodeURL parses the raw URL and re-encodes its query params
+func encodeURL(raw string) (string, error) {
+	endpoint, queryParamsRaw, ok := strings.Cut(raw, "?")
+	if !ok {
+		return raw, nil
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", &errortypes.BadInput{Message: fmt.Sprintf("invalid url %q: %v", raw, err)}
+	}
+
+	query := url.Values{}
+	for _, queryParam := range strings.Split(queryParamsRaw, "&") {
+		if k, v, _ := strings.Cut(queryParam, "="); k != "" {
+			query.Add(k, v)
+		}
+	}
+
+	u.RawQuery = query.Encode()
+
+	return u.String(), nil
 }
 
 func buildHeaders(request *openrtb2.BidRequest) http.Header {

--- a/adapters/genericvast/genericvast.go
+++ b/adapters/genericvast/genericvast.go
@@ -71,9 +71,14 @@ func encodeURL(raw string) (string, error) {
 
 	query := url.Values{}
 	for _, queryParam := range strings.Split(queryParamsRaw, "&") {
-		if k, v, _ := strings.Cut(queryParam, "="); k != "" {
-			query.Add(k, v)
+		k, v, _ := strings.Cut(queryParam, "=")
+		if k == "" {
+			continue
 		}
+		if decoded, err := url.QueryUnescape(v); err == nil {
+			v = decoded
+		}
+		query.Add(k, v)
 	}
 
 	u.RawQuery = query.Encode()

--- a/adapters/genericvast/genericvasttest/exemplary/url-encoding.json
+++ b/adapters/genericvast/genericvasttest/exemplary/url-encoding.json
@@ -1,0 +1,75 @@
+{
+  "mockBidRequest": {
+    "id": "req-1",
+    "site": {
+      "id": "site-1",
+      "page": "https://publisher.example.com/article",
+      "publisher": {"id": "pub-1"}
+    },
+    "device": {
+      "ua": "Mozilla/5.0",
+      "ip": "203.0.113.5",
+      "language": "en-US",
+      "dnt": 0
+    },
+    "imp": [
+      {
+        "id": "imp-1",
+        "video": {
+          "mimes": ["video/mp4"],
+          "w": 640,
+          "h": 360
+        },
+        "ext": {
+          "bidder": {
+            "url": "https://vast.example.com/tag?impid=imp-1&ua=Mozilla/5.0 (X11; Linux x86_64)"
+          }
+        }
+      }
+    ]
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://vast.example.com/tag?impid=imp-1&ua=Mozilla%2F5.0+%28X11%3B+Linux+x86_64%29",
+        "headers": {
+          "Accept": ["application/xml, text/xml, */*"],
+          "User-Agent": ["Mozilla/5.0"],
+          "X-Forwarded-For": ["203.0.113.5"],
+          "X-Device-Ip": ["203.0.113.5"],
+          "X-Real-Ip": ["203.0.113.5"],
+          "Accept-Language": ["en-US"],
+          "X-Device-Language": ["en-US"],
+          "Dnt": ["0"],
+          "Referer": ["https://publisher.example.com/article"],
+          "X-Device-Referer": ["https://publisher.example.com/article"]
+        },
+        "impIDs": ["imp-1"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": "<VAST version=\"4.0\"><Ad id=\"ad-1\"><InLine><AdSystem>VastExampleSSP</AdSystem><Advertiser>brand.example.com</Advertiser><Pricing model=\"cpm\" currency=\"USD\">2.50</Pricing><Creatives><Creative id=\"creative-1\"><Linear><Duration>00:00:30</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>"
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "ad-1",
+            "impid": "imp-1",
+            "price": 2.5,
+            "adm": "<VAST version=\"4.0\"><Ad id=\"ad-1\"><InLine><AdSystem>VastExampleSSP</AdSystem><Advertiser>brand.example.com</Advertiser><Pricing model=\"cpm\" currency=\"USD\">2.50</Pricing><Creatives><Creative id=\"creative-1\"><Linear><Duration>00:00:30</Duration></Linear></Creative></Creatives></InLine></Ad></VAST>",
+            "crid": "creative-1",
+            "dur": 30,
+            "adomain": ["brand.example.com"],
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adserver sends unencoded `url` to the prebid server. So, make sure to encode query params so that it's a valid HTTP GET request