### PR TITLE
[PLT-4880] copy teal bidder from pbs java

### DIFF
--- a/adapters/teal/teal.go
+++ b/adapters/teal/teal.go
@@ -83,29 +83,29 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 	}}, errors
 }
 
-func parseImpExt(imp openrtb2.Imp) (openrtb_ext.ImpTeal, error) {
+func parseImpExt(imp openrtb2.Imp) (openrtb_ext.ExtImpTeal, error) {
 	var bidderExt adapters.ExtImpBidder
 	if err := jsonutil.Unmarshal(imp.Ext, &bidderExt); err != nil {
-		return openrtb_ext.ImpTeal{}, &errortypes.BadInput{
+		return openrtb_ext.ExtImpTeal{}, &errortypes.BadInput{
 			Message: "Error parsing imp.ext for impression " + imp.ID,
 		}
 	}
 
-	var tealExt openrtb_ext.ImpTeal
+	var tealExt openrtb_ext.ExtImpTeal
 	if err := jsonutil.Unmarshal(bidderExt.Bidder, &tealExt); err != nil {
-		return openrtb_ext.ImpTeal{}, &errortypes.BadInput{
+		return openrtb_ext.ExtImpTeal{}, &errortypes.BadInput{
 			Message: "Error parsing imp.ext for impression " + imp.ID,
 		}
 	}
 
 	if err := validateImpExt(tealExt); err != nil {
-		return openrtb_ext.ImpTeal{}, err
+		return openrtb_ext.ExtImpTeal{}, err
 	}
 
 	return tealExt, nil
 }
 
-func validateImpExt(ext openrtb_ext.ImpTeal) error {
+func validateImpExt(ext openrtb_ext.ExtImpTeal) error {
 	if strings.TrimSpace(ext.Account) == "" {
 		return &errortypes.BadInput{Message: "account parameter failed validation"}
 	}

--- a/adapters/teal/teal.go
+++ b/adapters/teal/teal.go
@@ -1,0 +1,226 @@
+package teal
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/buger/jsonparser"
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v3/adapters"
+	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/errortypes"
+	"github.com/prebid/prebid-server/v3/openrtb_ext"
+	"github.com/prebid/prebid-server/v3/util/jsonutil"
+)
+
+type adapter struct {
+	endpoint string
+}
+
+// Builder builds a new instance of the Teal adapter for the given bidder with the given config.
+func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
+	return &adapter{
+		endpoint: config.Endpoint,
+	}, nil
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	var errors []error
+	var account string
+	modifiedImps := make([]openrtb2.Imp, 0, len(request.Imp))
+
+	for _, imp := range request.Imp {
+		tealExt, err := parseImpExt(imp)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		if account == "" {
+			account = tealExt.Account
+		}
+
+		modifiedImp, err := modifyImp(imp, tealExt.Placement)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		modifiedImps = append(modifiedImps, modifiedImp)
+	}
+
+	if len(modifiedImps) == 0 {
+		return nil, errors
+	}
+
+	ext, err := modifyRequestExt(request.Ext)
+	if err != nil {
+		return nil, append(errors, err)
+	}
+
+	// request is a per-bidder copy, but Site/App (and their Publisher) are
+	// pointers shared across bidders, so they are copied before mutation.
+	request.Imp = modifiedImps
+	request.Site = modifySite(request.Site, account)
+	request.App = modifyApp(request.App, account)
+	request.Ext = ext
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, append(errors, err)
+	}
+
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json;charset=utf-8")
+	headers.Add("Accept", "application/json")
+
+	return []*adapters.RequestData{{
+		Method:  http.MethodPost,
+		Uri:     a.endpoint,
+		Body:    body,
+		Headers: headers,
+		ImpIDs:  openrtb_ext.GetImpIDs(request.Imp),
+	}}, errors
+}
+
+func parseImpExt(imp openrtb2.Imp) (openrtb_ext.ImpTeal, error) {
+	var bidderExt adapters.ExtImpBidder
+	if err := jsonutil.Unmarshal(imp.Ext, &bidderExt); err != nil {
+		return openrtb_ext.ImpTeal{}, &errortypes.BadInput{
+			Message: "Error parsing imp.ext for impression " + imp.ID,
+		}
+	}
+
+	var tealExt openrtb_ext.ImpTeal
+	if err := jsonutil.Unmarshal(bidderExt.Bidder, &tealExt); err != nil {
+		return openrtb_ext.ImpTeal{}, &errortypes.BadInput{
+			Message: "Error parsing imp.ext for impression " + imp.ID,
+		}
+	}
+
+	if err := validateImpExt(tealExt); err != nil {
+		return openrtb_ext.ImpTeal{}, err
+	}
+
+	return tealExt, nil
+}
+
+func validateImpExt(ext openrtb_ext.ImpTeal) error {
+	if strings.TrimSpace(ext.Account) == "" {
+		return &errortypes.BadInput{Message: "account parameter failed validation"}
+	}
+
+	return nil
+}
+
+func modifyImp(imp openrtb2.Imp, placement string) (openrtb2.Imp, error) {
+	if placement == "" {
+		return imp, nil
+	}
+
+	placementValue, err := json.Marshal(placement)
+	if err != nil {
+		return openrtb2.Imp{}, &errortypes.BadInput{
+			Message: "Error modifying imp.ext for impression " + imp.ID,
+		}
+	}
+
+	modifiedExt, err := jsonparser.Set(imp.Ext, placementValue, "prebid", "storedrequest", "id")
+	if err != nil {
+		return openrtb2.Imp{}, &errortypes.BadInput{
+			Message: "Error modifying imp.ext for impression " + imp.ID,
+		}
+	}
+
+	imp.Ext = modifiedExt
+	return imp, nil
+}
+
+func modifySite(site *openrtb2.Site, account string) *openrtb2.Site {
+	if site == nil {
+		return nil
+	}
+
+	siteCopy := *site
+	siteCopy.Publisher = modifyPublisher(site.Publisher, account)
+	return &siteCopy
+}
+
+func modifyApp(app *openrtb2.App, account string) *openrtb2.App {
+	if app == nil {
+		return nil
+	}
+
+	appCopy := *app
+	appCopy.Publisher = modifyPublisher(app.Publisher, account)
+	return &appCopy
+}
+
+func modifyPublisher(publisher *openrtb2.Publisher, account string) *openrtb2.Publisher {
+	var publisherCopy openrtb2.Publisher
+	if publisher != nil {
+		publisherCopy = *publisher
+	}
+
+	publisherCopy.ID = account
+	return &publisherCopy
+}
+
+func modifyRequestExt(ext json.RawMessage) (json.RawMessage, error) {
+	if len(ext) == 0 {
+		return json.RawMessage(`{"bids":{"pbs":1}}`), nil
+	}
+
+	return jsonparser.Set(ext, []byte(`{"pbs":1}`), "bids")
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if adapters.IsResponseStatusCodeNoContent(response) {
+		return nil, nil
+	}
+
+	if err := adapters.CheckResponseStatusCodeForErrors(response); err != nil {
+		return nil, []error{err}
+	}
+
+	var bidResponse openrtb2.BidResponse
+	if err := jsonutil.Unmarshal(response.Body, &bidResponse); err != nil {
+		return nil, []error{&errortypes.BadServerResponse{Message: err.Error()}}
+	}
+
+	bidderResponse := adapters.NewBidderResponseWithBidsCapacity(len(request.Imp))
+	bidderResponse.Currency = bidResponse.Cur
+
+	for _, seatBid := range bidResponse.SeatBid {
+		for i := range seatBid.Bid {
+			bidderResponse.Bids = append(bidderResponse.Bids, &adapters.TypedBid{
+				Bid:     &seatBid.Bid[i],
+				BidType: getMediaTypeForImp(seatBid.Bid[i].ImpID, request.Imp),
+			})
+		}
+	}
+
+	return bidderResponse, nil
+}
+
+func getMediaTypeForImp(impID string, imps []openrtb2.Imp) openrtb_ext.BidType {
+	for i := range imps {
+		imp := &imps[i]
+		if imp.ID != impID {
+			continue
+		}
+
+		switch {
+		case imp.Banner != nil:
+			return openrtb_ext.BidTypeBanner
+		case imp.Video != nil:
+			return openrtb_ext.BidTypeVideo
+		case imp.Audio != nil:
+			return openrtb_ext.BidTypeAudio
+		case imp.Native != nil:
+			return openrtb_ext.BidTypeNative
+		}
+	}
+
+	return openrtb_ext.BidTypeBanner
+}

--- a/adapters/teal/teal_test.go
+++ b/adapters/teal/teal_test.go
@@ -1,0 +1,23 @@
+package teal
+
+import (
+	"testing"
+
+	"github.com/prebid/prebid-server/v3/adapters/adapterstest"
+	"github.com/prebid/prebid-server/v3/config"
+	"github.com/prebid/prebid-server/v3/openrtb_ext"
+)
+
+func TestJsonSamples(t *testing.T) {
+	bidder, buildErr := Builder(
+		openrtb_ext.BidderTeal,
+		config.Adapter{Endpoint: "https://a.bids.ws/openrtb2/auction"},
+		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"},
+	)
+
+	if buildErr != nil {
+		t.Fatalf("Builder returned unexpected error %v", buildErr)
+	}
+
+	adapterstest.RunJSONBidderTest(t, "tealtest", bidder)
+}

--- a/adapters/teal/tealtest/exemplary/simple-banner.json
+++ b/adapters/teal/tealtest/exemplary/simple-banner.json
@@ -1,0 +1,125 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-banner",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "account": "test-account",
+            "placement": "test-placement300x250"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/demo",
+      "publisher": {
+        "domain": "example.com"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://a.bids.ws/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-banner",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "account": "test-account",
+                  "placement": "test-placement300x250"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "test-placement300x250"
+                  }
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/demo",
+            "publisher": {
+              "id": "test-account",
+              "domain": "example.com"
+            }
+          },
+          "ext": {
+            "bids": {
+              "pbs": 1
+            }
+          }
+        },
+        "impIDs": [
+          "test-imp-banner"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "teal",
+              "bid": [
+                {
+                  "id": "teal-bid-1",
+                  "impid": "test-imp-banner",
+                  "price": 1.0,
+                  "adm": "<div>banner</div>",
+                  "crid": "creative-1",
+                  "w": 300,
+                  "h": 250,
+                  "mtype": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "teal-bid-1",
+            "impid": "test-imp-banner",
+            "price": 1.0,
+            "adm": "<div>banner</div>",
+            "crid": "creative-1",
+            "w": 300,
+            "h": 250,
+            "mtype": 1
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/teal/tealtest/exemplary/simple-native.json
+++ b/adapters/teal/tealtest/exemplary/simple-native.json
@@ -1,0 +1,102 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-native",
+        "native": {
+          "request": "{\"ver\":\"1.2\"}",
+          "ver": "1.2"
+        },
+        "ext": {
+          "bidder": {
+            "account": "test-account"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/demo"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://a.bids.ws/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-native",
+              "native": {
+                "request": "{\"ver\":\"1.2\"}",
+                "ver": "1.2"
+              },
+              "ext": {
+                "bidder": {
+                  "account": "test-account"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/demo",
+            "publisher": {
+              "id": "test-account"
+            }
+          },
+          "ext": {
+            "bids": {
+              "pbs": 1
+            }
+          }
+        },
+        "impIDs": [
+          "test-imp-native"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "teal",
+              "bid": [
+                {
+                  "id": "teal-bid-1",
+                  "impid": "test-imp-native",
+                  "price": 3.0,
+                  "adm": "{\"native\":{}}",
+                  "crid": "creative-1",
+                  "mtype": 4
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "teal-bid-1",
+            "impid": "test-imp-native",
+            "price": 3.0,
+            "adm": "{\"native\":{}}",
+            "crid": "creative-1",
+            "mtype": 4
+          },
+          "type": "native"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/teal/tealtest/exemplary/simple-video.json
+++ b/adapters/teal/tealtest/exemplary/simple-video.json
@@ -1,0 +1,117 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-video",
+        "video": {
+          "mimes": [
+            "video/mp4"
+          ],
+          "w": 640,
+          "h": 480
+        },
+        "ext": {
+          "bidder": {
+            "account": "test-account",
+            "placement": "test-placement-video"
+          }
+        }
+      }
+    ],
+    "app": {
+      "bundle": "com.example.app",
+      "publisher": {
+        "domain": "example.com"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://a.bids.ws/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-video",
+              "video": {
+                "mimes": [
+                  "video/mp4"
+                ],
+                "w": 640,
+                "h": 480
+              },
+              "ext": {
+                "bidder": {
+                  "account": "test-account",
+                  "placement": "test-placement-video"
+                },
+                "prebid": {
+                  "storedrequest": {
+                    "id": "test-placement-video"
+                  }
+                }
+              }
+            }
+          ],
+          "app": {
+            "bundle": "com.example.app",
+            "publisher": {
+              "id": "test-account",
+              "domain": "example.com"
+            }
+          },
+          "ext": {
+            "bids": {
+              "pbs": 1
+            }
+          }
+        },
+        "impIDs": [
+          "test-imp-video"
+        ]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "seat": "teal",
+              "bid": [
+                {
+                  "id": "teal-bid-1",
+                  "impid": "test-imp-video",
+                  "price": 2.0,
+                  "adm": "<VAST></VAST>",
+                  "crid": "creative-1",
+                  "mtype": 2
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "id": "teal-bid-1",
+            "impid": "test-imp-video",
+            "price": 2.0,
+            "adm": "<VAST></VAST>",
+            "crid": "creative-1",
+            "mtype": 2
+          },
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/teal/tealtest/supplemental/invalid-account.json
+++ b/adapters/teal/tealtest/supplemental/invalid-account.json
@@ -1,0 +1,29 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-banner",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "account": ""
+          }
+        }
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "account parameter failed validation",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/teal/tealtest/supplemental/invalid-imp-ext.json
+++ b/adapters/teal/tealtest/supplemental/invalid-imp-ext.json
@@ -1,0 +1,29 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-banner",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": [
+            "not-an-object"
+          ]
+        }
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Error parsing imp.ext for impression test-imp-banner",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/teal/tealtest/supplemental/status-code-error.json
+++ b/adapters/teal/tealtest/supplemental/status-code-error.json
@@ -1,0 +1,80 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-banner",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "account": "test-account"
+          }
+        }
+      }
+    ],
+    "site": {
+      "domain": "example.com",
+      "page": "https://example.com/demo"
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "https://a.bids.ws/openrtb2/auction",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-banner",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "account": "test-account"
+                }
+              }
+            }
+          ],
+          "site": {
+            "domain": "example.com",
+            "page": "https://example.com/demo",
+            "publisher": {
+              "id": "test-account"
+            }
+          },
+          "ext": {
+            "bids": {
+              "pbs": 1
+            }
+          }
+        },
+        "impIDs": [
+          "test-imp-banner"
+        ]
+      },
+      "mockResponse": {
+        "status": 500,
+        "body": {}
+      }
+    }
+  ],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 500. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -231,6 +231,7 @@ import (
 	"github.com/prebid/prebid-server/v3/adapters/taboola"
 	"github.com/prebid/prebid-server/v3/adapters/tappx"
 	"github.com/prebid/prebid-server/v3/adapters/teads"
+	"github.com/prebid/prebid-server/v3/adapters/teal"
 	"github.com/prebid/prebid-server/v3/adapters/telaria"
 	"github.com/prebid/prebid-server/v3/adapters/teqblaze"
 	"github.com/prebid/prebid-server/v3/adapters/theadx"
@@ -505,6 +506,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderTaboola:           taboola.Builder,
 		openrtb_ext.BidderTappx:             tappx.Builder,
 		openrtb_ext.BidderTeads:             teads.Builder,
+		openrtb_ext.BidderTeal:              teal.Builder,
 		openrtb_ext.BidderTelaria:           telaria.Builder,
 		openrtb_ext.BidderTeqBlaze:          teqblaze.Builder,
 		openrtb_ext.BidderTheadx:            theadx.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -249,6 +249,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderTaboola,
 	BidderTappx,
 	BidderTeads,
+	BidderTeal,
 	BidderTelaria,
 	BidderTeqBlaze,
 	BidderTheadx,
@@ -627,6 +628,7 @@ const (
 	BidderTaboola           BidderName = "taboola"
 	BidderTappx             BidderName = "tappx"
 	BidderTeads             BidderName = "teads"
+	BidderTeal              BidderName = "teal"
 	BidderTelaria           BidderName = "telaria"
 	BidderTeqBlaze          BidderName = "teqblaze"
 	BidderTheadx            BidderName = "theadx"

--- a/openrtb_ext/imp_teal.go
+++ b/openrtb_ext/imp_teal.go
@@ -1,7 +1,7 @@
 package openrtb_ext
 
-// ImpTeal defines the contract for bidrequest.imp[i].ext.prebid.bidder.teal
-type ImpTeal struct {
+// ExtImpTeal defines the contract for bidrequest.imp[i].ext.prebid.bidder.teal
+type ExtImpTeal struct {
 	Account   string `json:"account"`
 	Placement string `json:"placement,omitempty"`
 }

--- a/openrtb_ext/imp_teal.go
+++ b/openrtb_ext/imp_teal.go
@@ -1,0 +1,7 @@
+package openrtb_ext
+
+// ImpTeal defines the contract for bidrequest.imp[i].ext.prebid.bidder.teal
+type ImpTeal struct {
+	Account   string `json:"account"`
+	Placement string `json:"placement,omitempty"`
+}

--- a/static/bidder-info/teal.yaml
+++ b/static/bidder-info/teal.yaml
@@ -1,0 +1,23 @@
+endpoint: "https://a.bids.ws/openrtb2/auction"
+endpointCompression: gzip
+maintainer:
+  email: prebid@teal.works
+gvlVendorID: 1378
+modifyingVastXmlAllowed: true
+openrtb:
+  version: 2.6
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - video
+      - native
+  site:
+    mediaTypes:
+      - banner
+      - video
+      - native
+userSync:
+  iframe:
+    url: "https://bids.ws/load-pbs.html?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect_url={{.RedirectURL}}"
+    userMacro: "{UID}"

--- a/static/bidder-params/teal.json
+++ b/static/bidder-params/teal.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Teal Adapter Params",
+  "description": "A schema which validates params accepted by the Teal adapter",
+  "type": "object",
+  "properties": {
+    "account": {
+      "type": "string",
+      "description": "Account ID"
+    },
+    "placement": {
+      "type": "string",
+      "description": "Placement ID or name (optional)"
+    }
+  },
+  "required": [
+    "account"
+  ]
+}


### PR DESCRIPTION
Copy `teal` bidder from PBS java version. There is no official `teal` bidder in PBS go.

Original code is here: https://github.com/prebid/prebid-server-java/blob/master/src/main/java/org/prebid/server/bidder/teal/TealBidder.java